### PR TITLE
Implement RootType on failfs

### DIFF
--- a/failfs.go
+++ b/failfs.go
@@ -1,9 +1,10 @@
 package asset
 
 import (
-	"golang.org/x/tools/godoc/vfs"
 	"fmt"
 	"os"
+
+	"golang.org/x/tools/godoc/vfs"
 )
 
 type failFS struct {
@@ -28,4 +29,10 @@ func (fs *failFS) ReadDir(path string) ([]os.FileInfo, error) {
 }
 func (fs *failFS) String() string {
 	return fmt.Sprintf("failfs(%q)", fs.err)
+}
+
+// An empty RootType signifies that the filesystem is neither a GOPATH nor a
+// GOROOT
+func (fs *failFS) RootType(path string) vfs.RootType {
+	return ""
 }


### PR DESCRIPTION
A RootType method was added to the FileSystem interface in order to indicate whether the FS represents a GOROOT or a GOPATH. In the case that the FS represents neither, an empty string is used.

The method was added to the interface in [16d1af8d88c08b6a22e07a0900aad5279a7fb4fd](https://github.com/golang/tools/commit/16d1af8d88c08b6a22e07a0900aad5279a7fb4fd#diff-18fea54478aaeb3bf86f30bb19133f8eR34) in github.com/golang/tools, and the implementation was updated in [8b3cccae50961d427273d41c8a6ad18bfa623e08](https://github.com/golang/tools/commit/8b3cccae50961d427273d41c8a6ad18bfa623e08#diff-5b68f17230b6638cb57ed3fdf61b9cf2) to clarify the usage of empty string as the default value.